### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,5 @@
+2013-07-09 Release 0.1.1
+
+Bugfixes:
+- librarian-puppet does not understand semver 1.0.0 versions.
+https://github.com/rodjek/librarian-puppet/issues/70

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-vswitch'
-version '0.1.0-pl1'
+version '0.1.1'
 source  'https://github.com/puppetlabs/puppetlabs-vswitch'
 author  'Endre Karlson, Dan Bode, Ian Wells'
 license 'Apache License 2.0'


### PR DESCRIPTION
Bugfixes:
- librarian-puppet does not understand semver 1.0.0 versions.
  https://github.com/rodjek/librarian-puppet/issues/70
